### PR TITLE
change argument in network.py to adapt to new changes in tensorflow

### DIFF
--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -177,7 +177,7 @@ class Network(object):
 
     @layer
     def concat(self, inputs, axis, name):
-        return tf.concat(values=inputs, concat_dim=axis,  name=name)
+        return tf.concat(values=inputs, axis=axis,  name=name)
 
     @layer
     def add(self, inputs, name):


### PR DESCRIPTION
In tensorflow 1.2, the second argument was changed from concat_dim to axis
concat(
    values,
    axis,
    name='concat'
)
